### PR TITLE
Enable element-level predicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .bundle/
 log/*.log
 pkg/

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem "puma"
 
 gem "riddler", path: "riddler"
 
+gem "predicator", github: "predicator/predicator"
+
 group :development do
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/predicator/predicator.git
+  revision: a8fdc974b96ae1a59e821462f64c4a1b9ae14d6a
+  specs:
+    predicator (1.2.0)
+
 PATH
   remote: .
   specs:
@@ -188,6 +194,7 @@ PLATFORMS
 
 DEPENDENCIES
   pg
+  predicator!
   pry
   pry-byebug
   pry-rails
@@ -198,4 +205,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/riddler_admin/elements_controller.rb
+++ b/app/controllers/riddler_admin/elements_controller.rb
@@ -68,12 +68,12 @@ module RiddlerAdmin
 
       # Only allow a trusted parameter "white list" through.
       def element_create_params
-        params.require(:element).permit(:id, :name, :type, :text, :container_type, :container_id, :href)
+        params.require(:element).permit(:id, :name, :type, :text, :container_type, :container_id, :href, :include_predicate)
       end
 
       # Only allow a trusted parameter "white list" through.
       def element_params
-        params.require(:element).permit(:name, :text, :href)
+        params.require(:element).permit(:name, :text, :href, :include_predicate)
       end
   end
 end

--- a/app/views/riddler_admin/_element.html.erb
+++ b/app/views/riddler_admin/_element.html.erb
@@ -19,8 +19,8 @@
 
       <div class="form-group col-md-6">
         <%= f.label :include_predicate %>
-        <%= f.text_field :include_predicate, class: "form-control" %>
-        <small class="form-text text-muted">Should this element be included?</small>
+        <%= f.text_field :include_predicate, class: "form-control", placeholder: "e.g. parms.user_id is present" %>
+        <small class="form-text text-muted">Use data from the context that evaluates to <code>true</code> or <code>false</code></small>
       </div>
     </div>
 

--- a/app/views/riddler_admin/_element.html.erb
+++ b/app/views/riddler_admin/_element.html.erb
@@ -16,6 +16,12 @@
         <%= f.text_field :name, class: 'form-control' %>
         <small class="form-text text-muted">Cannot start with a capital letter or a number.</small>
       </div>
+
+      <div class="form-group col-md-6">
+        <%= f.label :include_predicate %>
+        <%= f.text_field :include_predicate, class: "form-control" %>
+        <small class="form-text text-muted">Should this element be included?</small>
+      </div>
     </div>
 
     <%= render partial: element.to_partial_path("form"), locals: { f: f } %>

--- a/app/views/riddler_admin/elements/_new.html.erb
+++ b/app/views/riddler_admin/elements/_new.html.erb
@@ -23,10 +23,18 @@
     <%= f.hidden_field :container_type %>
     <%= f.hidden_field :container_id %>
 
-    <div class="form-group">
-      <%= f.label :name, 'Element ID' %>
-      <%= f.text_field :name, class: 'form-control' %>
-      <small class="form-text text-muted">Cannot start with a capital letter or a number.</small>
+    <div class="form-row well">
+      <div class="form-group col-md-6">
+        <%= f.label :name, 'Element ID' %>
+        <%= f.text_field :name, class: 'form-control' %>
+        <small class="form-text text-muted">Cannot start with a capital letter or a number.</small>
+      </div>
+
+      <div class="form-group col-md-6">
+        <%= f.label :include_predicate %>
+        <%= f.text_field :include_predicate, class: "form-control", placeholder: "e.g. parms.user_id is present" %>
+        <small class="form-text text-muted">Use data from the context that evaluates to <code>true</code> or <code>false</code></small>
+      </div>
     </div>
 
     <%= render partial: "#{@element.to_partial_path}/form", locals: { f: f } %>

--- a/app/views/riddler_admin/elements/heading/_form.html.erb
+++ b/app/views/riddler_admin/elements/heading/_form.html.erb
@@ -1,2 +1,5 @@
 <%= f.label :text %>
 <%= f.text_field :text %>
+
+<%= f.label :include_predicate %>
+<%= f.text_field :include_predicate %>

--- a/app/views/riddler_admin/elements/image/_form.html.erb
+++ b/app/views/riddler_admin/elements/image/_form.html.erb
@@ -3,3 +3,6 @@
 
 <%= f.label :href %>
 <%= f.text_field :href %>
+
+<%= f.label :include_predicate %>
+<%= f.text_field :include_predicate %>

--- a/app/views/riddler_admin/elements/link/_form.html.erb
+++ b/app/views/riddler_admin/elements/link/_form.html.erb
@@ -3,3 +3,6 @@
 
 <%= f.label :href %>
 <%= f.text_field :href %>
+
+<%= f.label :include_predicate %>
+<%= f.text_field :include_predicate %>

--- a/app/views/riddler_admin/elements/text/_form.html.erb
+++ b/app/views/riddler_admin/elements/text/_form.html.erb
@@ -1,2 +1,5 @@
 <%= f.label :text %>
 <%= f.text_area :text %>
+
+<%= f.label :include_predicate %>
+<%= f.text_field :include_predicate %>

--- a/db/migrate/20181124201519_create_riddler_admin_steps.rb
+++ b/db/migrate/20181124201519_create_riddler_admin_steps.rb
@@ -16,6 +16,7 @@ class CreateRiddlerAdminSteps < ActiveRecord::Migration[5.2]
       t.integer :position
       t.string :text
       t.string :href
+      t.string :include_predicate, default: "true"
     end
   end
 end

--- a/db/migrate/20181124201519_create_riddler_admin_steps.rb
+++ b/db/migrate/20181124201519_create_riddler_admin_steps.rb
@@ -16,7 +16,7 @@ class CreateRiddlerAdminSteps < ActiveRecord::Migration[5.2]
       t.integer :position
       t.string :text
       t.string :href
-      t.string :include_predicate, default: "true"
+      t.string :include_predicate
     end
   end
 end

--- a/riddler/lib/riddler/context.rb
+++ b/riddler/lib/riddler/context.rb
@@ -24,6 +24,10 @@ module Riddler
       template.render variables
     end
 
+    def to_liquid
+      Liquid::Context.new [variables]
+    end
+
     def method_missing method_name, *_args
       return super unless variables.key? method_name.to_s
       variable method_name

--- a/riddler/lib/riddler/context_builder.rb
+++ b/riddler/lib/riddler/context_builder.rb
@@ -1,5 +1,4 @@
 module Riddler
-
   class ContextBuilder
     attr_reader :params, :headers
 
@@ -12,5 +11,4 @@ module Riddler
       ::Riddler::Context.new params: params, headers: headers
     end
   end
-
 end

--- a/riddler/lib/riddler/element.rb
+++ b/riddler/lib/riddler/element.rb
@@ -7,9 +7,14 @@ module Riddler
       element_type = definition["object"]
 
       # Maybe this should be a registry
-      klass = subclasses.detect { |klass| klass.type == element_type }
+      klazz = subclasses.detect { |klass| klass.type == element_type }
 
-      klass.new definition, context
+      klazz.new definition, context
+    end
+
+    def include?
+      predicate = definition["include_predicate"]
+      Predicator.evaluate(predicate, context.variables["params"])
     end
 
     def initialize definition, context

--- a/riddler/lib/riddler/element.rb
+++ b/riddler/lib/riddler/element.rb
@@ -13,8 +13,9 @@ module Riddler
     end
 
     def include?
+      return true unless has_include_predicate?
       predicate = definition["include_predicate"]
-      Predicator.evaluate(predicate, context.variables["params"])
+      Predicator.evaluate predicate, context.to_liquid
     end
 
     def initialize definition, context
@@ -29,5 +30,13 @@ module Riddler
         name: definition["name"]
       }
     end
+
+    private
+
+    def has_include_predicate?
+      definition.key?("include_predicate") and
+        definition["include_predicate"].strip != ""
+    end
+
   end
 end

--- a/riddler/lib/riddler/elements/heading.rb
+++ b/riddler/lib/riddler/elements/heading.rb
@@ -14,6 +14,5 @@ module Riddler
         super.merge text: text
       end
     end
-
   end
 end

--- a/riddler/lib/riddler/step.rb
+++ b/riddler/lib/riddler/step.rb
@@ -1,5 +1,4 @@
 module Riddler
-
   class Step
     attr_reader :definition, :context
 
@@ -18,14 +17,6 @@ module Riddler
       @context = context
     end
 
-    #def id
-    #  definition["id"]
-    #end
-
-    #def type
-    #  self.class.type
-    #end
-
     def to_hash
       {
         type: self.class.type,
@@ -33,5 +24,4 @@ module Riddler
       }
     end
   end
-
 end

--- a/riddler/lib/riddler/steps/content.rb
+++ b/riddler/lib/riddler/steps/content.rb
@@ -1,15 +1,16 @@
 module Riddler
   module Steps
-
     class Content < ::Riddler::Step
       def self.type
         "content"
       end
 
       def elements
-        @elements ||= definition["elements"].map do |element_definition|
-          ::Riddler::Element.for element_definition, context
-        end
+        @elements ||= definition["elements"]
+          .map do |element_definition|
+            ::Riddler::Element.for element_definition, context
+          end
+          .select(&:include?)
       end
 
       def to_hash
@@ -20,6 +21,5 @@ module Riddler
         hash
       end
     end
-
   end
 end

--- a/riddler/lib/riddler/use_cases/preview_step.rb
+++ b/riddler/lib/riddler/use_cases/preview_step.rb
@@ -1,6 +1,5 @@
 module Riddler
   module UseCases
-
     class PreviewStep
       attr_reader :definition, :params, :headers, :step
 
@@ -23,6 +22,5 @@ module Riddler
         step.to_hash
       end
     end
-
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_201519) do
     t.integer "position"
     t.string "text"
     t.string "href"
-    t.string "include_predicate", default: "true"
+    t.string "include_predicate"
     t.index ["container_type", "container_id"], name: "index_riddler_elements_on_container_type_and_container_id"
     t.index ["id"], name: "index_riddler_elements_on_id"
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2018_11_24_201519) do
     t.integer "position"
     t.string "text"
     t.string "href"
+    t.string "include_predicate", default: "true"
     t.index ["container_type", "container_id"], name: "index_riddler_elements_on_container_type_and_container_id"
     t.index ["id"], name: "index_riddler_elements_on_id"
   end


### PR DESCRIPTION
Enables setting a predicate on any element for conditional display. The predicate is evaluated on the server, so clients don't even need to know about elements which were filtered out.